### PR TITLE
fix 生成控制器的序号

### DIFF
--- a/Unity/Assets/Scripts/Editor/Plugins/FairyGUI/CodeSpawn/FUIComponentSpawner.cs
+++ b/Unity/Assets/Scripts/Editor/Plugins/FairyGUI/CodeSpawn/FUIComponentSpawner.cs
@@ -52,6 +52,7 @@ namespace FUIEditor
             
             for (int i = 0; i < ControllerNames.Count; i++)
             {
+                if (string.IsNullOrEmpty(ControllerNames[i])) continue;
                 sb.AppendFormat("\t\tpublic Controller {0};", ControllerNames[i]);
                 sb.AppendLine();
             }
@@ -102,6 +103,7 @@ namespace FUIEditor
 
             for (int i = 0; i < ControllerNames.Count; i++)
             {
+                if (string.IsNullOrEmpty(ControllerNames[i])) continue;
                 sb.AppendFormat("\t\t\t{0} = GetControllerAt({1});", ControllerNames[i], i);
                 sb.AppendLine();
             }
@@ -188,6 +190,7 @@ namespace FUIEditor
                 string controllerName = controllerXML.GetAttribute("name");
                 if (!CheckControllerName(controllerName, componentInfo.ComponentType))
                 {
+                    ControllerNames.Add("");
                     continue;
                 }
 


### PR DESCRIPTION
修复了一个控制器生成的bug 原来如果默认button控制器在第一个 就会跳过 导致自定义的控制器获取从0开始 其实就会获取到button的控制器